### PR TITLE
42 bug check worktree is dirty work error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,61 @@
 ```json
 {
   "types": [
-    {"type": "feat", "section": "✨ Features", "hidden": false},
-    {"type": "fix", "section": "🐛 Bug Fixes", "hidden": false},
-    {"type": "docs", "section":"📝 Documentation", "hidden": false},
-    {"type": "style", "section":"💄 Styles", "hidden": true},
-    {"type": "refactor", "section":"♻ Refactor", "hidden": false},
-    {"type": "perf", "section":"⚡ Performance Improvements", "hidden": false},
-    {"type": "test", "section":"✅ Tests", "hidden": true},
-    {"type": "build", "section":"👷‍ Build System", "hidden": false},
-    {"type": "ci", "section":"🔧 Continuous Integration", "hidden": true},
-    {"type": "chore", "section":"📦 Chores", "hidden": true},
-    {"type": "revert", "section":"⏪ Reverts", "hidden": false}
+    {
+      "type": "feat",
+      "section": "✨ Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "🐛 Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": "📝 Documentation",
+      "hidden": false
+    },
+    {
+      "type": "style",
+      "section": "💄 Styles",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "♻ Refactor",
+      "hidden": false
+    },
+    {
+      "type": "perf",
+      "section": "⚡ Performance Improvements",
+      "hidden": false
+    },
+    {
+      "type": "test",
+      "section": "✅ Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "👷‍ Build System",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "🔧 Continuous Integration",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "📦 Chores",
+      "hidden": true
+    },
+    {
+      "type": "revert",
+      "section": "⏪ Reverts",
+      "hidden": false
+    }
   ],
   "tag-prefix": "v"
 }
@@ -74,6 +118,7 @@
     - use cli flag `--git-info-scheme` to change git info scheme, only support: https, http
     - in `.versionrc` has `cover-git-info-scheme` field as string, will change remote for example fill in `http`
 - [x] check worktree is dirty (v1.8+)
+    - add flag `--skip-worktree-check` will skip check (v1.8.1+)
     - check repository is dirty like `git status --porcelain`
     - if repository has submodule, will check, like `git submodule status --recursive`
 
@@ -117,6 +162,8 @@ $ convention-change-log init
 # if there is a log of type `feat`，then increment the MINOR version
 # if there is no log of type `feat`, then increment the PATCH version
 $ convention-change-log --dry-run
+# --skip-worktree-check will skip check worktree (v1.8.1+)
+$ convention-change-log --dry-run --skip-worktree-check
 
 # flat -r to set custom release version
 $ convention-change-log -r 0.1.0 --dry-run

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 - [x] git url scheme default is `https` can change.(v1.8+)
     - use cli flag `--git-info-scheme` to change git info scheme, only support: https, http
     - in `.versionrc` has `cover-git-info-scheme` field as string, will change remote for example fill in `http`
-- [x] local repository dirty check (v1.8+)
+- [x] check worktree is dirty (v1.8+)
     - check repository is dirty like `git status --porcelain`
     - if repository has submodule, will check, like `git submodule status --recursive`
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -48,6 +48,8 @@ $ convention-change-log init
 # 如果 含有 类型 `feat` 的日志，则在最后一个版本上 次版本号 +1
 # 如果 没有 类型 `feat` 的日志，则在最后一个版本上 修订号 +1
 $ convention-change-log --dry-run
+# --skip-worktree-check 将跳过检查 worktree (v1.8.1+)
+$ convention-change-log --dry-run --skip-worktree-check
 
 # 设置 -r 自定义发布版本
 $ convention-change-log -r 0.1.0 --dry-run

--- a/cmd/kit/command/change_log_generator.go
+++ b/cmd/kit/command/change_log_generator.go
@@ -43,6 +43,8 @@ type ChangeLogGeneratorFunc interface {
 
 	CheckRepository() error
 
+	CheckWorktreeDirty() error
+
 	GetHeadBranchName() string
 
 	GetGitRemoteInfo() git_info.GitRemoteInfo
@@ -77,4 +79,6 @@ type GenerateConfig struct {
 	FromCommit string
 
 	AutoPush bool
+
+	SkipWorktreeDirtyCheck bool
 }

--- a/cmd/kit/command/flag.go
+++ b/cmd/kit/command/flag.go
@@ -79,6 +79,11 @@ func GlobalFlag() []cli.Flag {
 			Value:   "https",
 			EnvVars: []string{constant.EnvKeyGitInfoScheme},
 		},
+		&cli.BoolFlag{
+			Name:    "skip-worktree-check",
+			Usage:   "skip git worktree dirty check",
+			EnvVars: []string{constant.EnvKeySkipWorktreeCheck},
+		},
 	}
 }
 

--- a/cmd/kit/constant/env.go
+++ b/cmd/kit/constant/env.go
@@ -11,6 +11,8 @@ const (
 
 	EnvKeyGitInfoScheme = "CLI_GIT_INFO_SCHEME"
 
+	EnvKeySkipWorktreeCheck = "CLI_SKIP_WORKTREE_CHECK"
+
 	// EnvKeyCliTimeoutSecond
 	//	Provides the timeout second flag
 	EnvKeyCliTimeoutSecond = "CLI_CONFIG_TIMEOUT_SECOND"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gookit/color v1.5.4
 	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/sinlov-go/go-common-lib v1.7.0
-	github.com/sinlov-go/go-git-tools v1.12.0
+	github.com/sinlov-go/go-git-tools v1.13.0
 	github.com/sinlov-go/sample-markdown v1.4.0
 	github.com/sinlov-go/unittest-kit v1.1.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sinlov-go/go-common-lib v1.7.0 h1:1/zLoIPYRw26haBGU3kw0o8vmSw3bfqQMuK9TtizMn4=
 github.com/sinlov-go/go-common-lib v1.7.0/go.mod h1:B8iZES6+7p3uldjyF6zGv7BG8r0iPgndALZRmiSqkDQ=
-github.com/sinlov-go/go-git-tools v1.12.0 h1:65zo0fG+MfNnwRzNx+ieecchdylUzqLYCMhMvxlxA8g=
-github.com/sinlov-go/go-git-tools v1.12.0/go.mod h1:p5KlfInd3XjQgZtuGavWfgs5LgB1EEzMMivwt/sMkRE=
+github.com/sinlov-go/go-git-tools v1.13.0 h1:ty+/9O9eTYMAUeYtZDtW/n2YjhkQhgSXDhxVRCI244g=
+github.com/sinlov-go/go-git-tools v1.13.0/go.mod h1:p5KlfInd3XjQgZtuGavWfgs5LgB1EEzMMivwt/sMkRE=
 github.com/sinlov-go/sample-markdown v1.4.0 h1:79fVH3Asz7cGvPuPkqMVtPV8FVqoAymqMW0z3extQBU=
 github.com/sinlov-go/sample-markdown v1.4.0/go.mod h1:F9jkQUrZIHLDr2j31PhFbpJUQpwp8CD48QA9DGPP1bY=
 github.com/sinlov-go/unittest-kit v1.1.0 h1:mT3cnhe+LAlvOoxkAggi4xQDOT58Q3az4XKV3R5cdJM=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convention-change-log",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "generate changelog from conventional commits",
   "repository": {
     "type": "git",


### PR DESCRIPTION
fix #42 

- add flag `--skip-worktree-check` will skip check (v1.8.1+)
- let worktree dirty check use git command frist, if not find just use github.com/go-git/go-git/v5