### PR TITLE
99 feature Add global --skip-branch flag

### DIFF
--- a/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
+++ b/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
@@ -1,7 +1,7 @@
 ---
 id: 0001-feat-check-workspace-brach-is-default-branch
 title: check workspace brach is default branch
-status: in-progress
+status: done
 owner: "sinlovppt"
 locked_at: ""
 priority: medium
@@ -21,7 +21,7 @@ after v1.14+ , must check branch for `main` branch
   - config setting at `.versionrc` key `branch-check`, will with array of string, if not set, will check `main` branch only
   - match `branch-check` setting use golang package `github.com/bmatcuk/doublestar/v4`
   - default config setting is `["main"]` if not set, will check `main` branch only, and will effect at sub command `init`
-  - `--dry-run` mode will check `branch-check` setting, if not match, will print warning message, but not exit with error code
+  - `--dry-run` mode will check `branch-check` setting, if not match, will append warning message at tail of output, but not exit with error code
 
 ## do task
 
@@ -39,3 +39,4 @@ after v1.14+ , must check branch for `main` branch
   - go vet
 - check new feature with `--dry-run` mode, and check warning message
 - check new feature with `--skip-branch` mode, and check warning message
+

--- a/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
+++ b/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
@@ -16,7 +16,7 @@ created_at: "2026-08-05"
 ### Suggested solution
 
 after v1.14+ , must check branch for `main` branch
-- add flat `--skip-branch` at global flag, to pass check branch
+- add flag `--skip-branch` at global flag, to pass check branch
 - add config `check branch with match list`
   - config setting at `.versionrc` key `branch-check`, will with array of string, if not set, will check `main` branch only
   - match `branch-check` setting use golang package `github.com/bmatcuk/doublestar/v4`

--- a/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
+++ b/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
@@ -1,0 +1,12 @@
+---
+id: 0001-feat-check-workspace-brach-is-default-branch
+title: check workspace brach is default branch
+status: in-progress
+owner: "sinlovppt"
+locked_at: ""
+priority: medium
+category: feat
+created_at: "2026-08-05"
+---
+
+TODO: fill in the task content

--- a/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
+++ b/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
@@ -1,6 +1,6 @@
 ---
 id: 0001-feat-check-workspace-brach-is-default-branch
-title: check workspace brach is default branch
+title: check workspace branch is default branch
 status: done
 owner: "sinlovppt"
 locked_at: ""

--- a/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
+++ b/.shared/tasks/feat/0001-feat-check-workspace-brach-is-default-branch.md
@@ -9,4 +9,33 @@ category: feat
 created_at: "2026-08-05"
 ---
 
-TODO: fill in the task content
+## feature description
+
+- let generate workspace branch is default branch
+
+### Suggested solution
+
+after v1.14+ , must check branch for `main` branch
+- add flat `--skip-branch` at global flag, to pass check branch
+- add config `check branch with match list`
+  - config setting at `.versionrc` key `branch-check`, will with array of string, if not set, will check `main` branch only
+  - match `branch-check` setting use golang package `github.com/bmatcuk/doublestar/v4`
+  - default config setting is `["main"]` if not set, will check `main` branch only, and will effect at sub command `init`
+  - `--dry-run` mode will check `branch-check` setting, if not match, will print warning message, but not exit with error code
+
+## do task
+
+- update code at `cmd/kit/command/`
+- this change will record at `doc/feature/99-feat-check-workspace-brach-is-default-branch.md` file
+- must update usage guide at
+  - `README.md`
+  - `README.zh-Hans.md`
+
+## check task
+
+- check as this project setting
+  - go unit test
+  - go lint
+  - go vet
+- check new feature with `--dry-run` mode, and check warning message
+- check new feature with `--skip-branch` mode, and check warning message

--- a/.versionrc
+++ b/.versionrc
@@ -13,5 +13,6 @@
     {"type": "revert", "section":"⏪ Reverts", "hidden": false}
   ],
   "tag-prefix": "v",
-  "monorepo-pkg-path": []
+  "monorepo-pkg-path": [],
+  "branch-check": ["main"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md
+
+Repo-specific guidance for OpenCode agents working on `convention-change-log`,
+a Go CLI that generates changelogs from Conventional Commits. Keep this file
+short and high-signal; verify against the code if anything looks stale.
+
+## Toolchain
+
+- **Go 1.25** required (`go.mod`: `go 1.25.0`, toolchain `go1.25.11`). CI matrix
+  tests `^1.25` and `1.25.11`.
+- `package.json` at the repo root is **not a Node project**. It is Go-embedded
+  metadata (`//go:embed package.json` in `resource.go`) consumed by the CLI for
+  name/version/author. The release flow rewrites its `version` field. The real
+  JS package is `.opencode/package.json` (OpenCode tooling only, CI-ignored).
+- `golangci-lint` **v2** is the active linter. Config is `.golangci-v2.yaml`
+  (used by both `make style` and CI). `.golangci.yaml` is the legacy v1 config
+  — do not edit it expecting changes to take effect. v2 config has `tests: false`
+  (test files are not linted), `modules-download-mode: readonly`, and
+  `new-from-merge-base: main` (only new issues vs `main` are reported).
+
+## Commands (Makefile is the source of truth)
+
+```bash
+make init dep      # first-time setup: check Go env, verify/download/tidy modules
+make test          # fast unit tests
+make style         # go mod verify + tidy + fmt + golangci-lint v2 (local style check)
+make ci            # style + go vet + test + run.help  (local CI replica)
+make ci.all        # ci + benchmark + coverage show
+make buildMain     # build ./build/convention-change-log
+make dev / dev.help  # build then run with CI_DEBUG=true / -h
+make clean         # remove build/, logs/, coverage files
+```
+
+- To run a single Go test, match CI's invocation: `go test -tags test -run <Name> ./<pkg>/...`
+- Benchmarks and coverage targets always pass `-tags test`; `make test` itself
+  does not, but CI runs `go test -v -tags test ./...`. Prefer `-tags test`.
+- Integration test coverage (binary-instrumented) is separate:
+  `make test.go.integration.run` (uses `GOCOVERDIR`, not the unit-test profile).
+
+## Build tags
+
+`cmd/convention-change-log/main.go` and `example/TestMain.go` carry
+`//go:build !test`. CI builds and tests with `-tags test`, so the main binary
+source is excluded under the test tag. When running `go build`/`go test` by hand
+to match CI, pass `-tags test`. `make` targets already handle this where needed.
+
+## Tests and golden files
+
+- Test stack: `stretchr/testify` + `sebdah/goldie/v2` (golden-file assertions).
+  `goldie.New(t, goldie.WithDiffEngine(...))` is the common pattern; no custom
+  fixture dir, so golden files land next to the test as `testdata/*.golden`.
+- Golden/testdata files live under `<pkg>/testdata/` (36 tracked `.golden`
+  files across `changelog/`, `convention/`, `example_test/`).
+- **Critical gitignore trap:** `.gitignore` has `test[Dd]ata/` and `*.golden`
+  patterns. Existing files are tracked only because git keeps tracking files
+  after they were added. **New** `testdata/` or `*.golden` files are silently
+  ignored — `git add -f <file>` is required, or they will not be committed and
+  tests will fail for others. Always check `git status --ignored` after creating
+  fixtures.
+- To regenerate goldens, goldie respects its update flag; confirm the new output
+  is actually tracked (see trap above) before committing.
+
+## Package layout
+
+- `cmd/convention-change-log/main.go` — CLI entry (build tag `!test`).
+- `cmd/kit/cli/` — builds the `urfave/cli/v2` app (`NewCliApp`).
+- `cmd/kit/command/` — command + flag logic: `global.go`, `flag.go`,
+  `change_log_generator*.go`, and subcommand packages `subcommand_init/`,
+  `subcommand_read_latest/`.
+- `convention/` — **core domain**: commit parsing, changelog spec
+  (`changeLogSpec.go`), template rendering, git repo info, types. Pure logic.
+- `changelog/` — markdown node generation (`markdown.go`) and reader
+  (`reader.go`); the output layer over `convention/`.
+- `internal/` — private: `log/`, `pkg_kit/`, `tools/`, `urfave_cli/`.
+- `constant/version.go` — version + copyright-year constants.
+- `resource.go` — `//go:embed` of `package.json` and
+  `resource/versionrc-beauty.json`.
+- `z-MakefileUtils/` — included Makefile fragments; excluded from lint.
+
+## Core behavior (version bump rules)
+
+Default SemVer bump from commit types since the last tag:
+
+- any `feat:` → **MINOR**
+- otherwise → **PATCH**
+- `BREAKING CHANGE:` or `BREAKING-CHANGE:` footer (or `!` after type) → **MAJOR**
+- `-r`/`--release-as` overrides; no `feat` means PATCH.
+
+This is the behavior the tool implements and also dogfoods for its own releases.
+
+## Config and dogfooding
+
+- `.versionrc` is the tool's own release config **and** the format it generates
+  for users. `tag-prefix: "v"`, `monorepo-pkg-path: []`. Editing it changes this
+  repo's own changelog generation.
+- Conventional Commits are **required** for this repo's history (the repo
+  consumes its own output). Commit format used here:
+  `<type>[scope]: <emoji> <description>`. The `/gitcc` OpenCode command
+  (`.opencode/commands/gitcc.md`) generates compliant messages.
+- `.opencode/` and `.shared/` are **ignored by CI** (`ci.yml` `paths-ignore`).
+  They are local tooling/config, not part of the build or test surface.
+
+## Debug / env toggles
+
+- `CLI_VERBOSE=true` — verbose CLI output (`make run.debug` / `make dev` set this).
+- `CI_DEBUG=true` — debug mode for `make dev`.
+- `CLI_DRY_RUN_DISABLE` — disable dry-run (the tool defaults to dry-run since v1.7).
+- `CLI_LOG_LEVEL`, `CLI_CONFIG_TIMEOUT_SECOND`, `CLI_GIT_INFO_SCHEME`,
+  `CLI_SKIP_WORKTREE_CHECK` — other runtime toggles.
+
+## Release / CI flow
+
+- Push a tag → `go-release-platform.yml` cross-builds
+  (linux/darwin/windows × amd64/arm64, `CGO_ENABLED=0`, static) →
+  `deploy-tag.yml` creates a GitHub Release with archive + `.sha256` assets.
+- `version.yml` uses `convention-change/conventional-version-check@v1.5.0` to
+  derive version/changelog for the release body.
+- CI triggers on branches: `release-*`, `FE-*`, `*-feature-*`,
+  `*-enhancement-*`, `BF-*`, `*-bug-*`, `PU-*`, `DOC-*`, `*-documentation-*`,
+  `*-hotfix-*`, and on all tags. `main` builds but release artifacts only ship
+  from tags.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
             - commit message contains `feat:` will update `MINOR` version
             - commit message not contains `feat:` will update `PATCH` version
     - [x] `--auto-push` flag can auto push tag to remote
+    - [x] `--skip-branch` flag can skip branch check (v1.14+)
     - [x] `--tag-prefix` flag can change tag prefix, default will use `.versionrc` config `tag-prefix`
 - generate from [conventional commits](https://www.conventionalcommits.org) for [semver.org](https://semver.org/)
     - [x] default will update `PATCH` version
@@ -105,6 +106,7 @@
     - [x] project has `package-lock.json` file, will try use `npm install` to update `package-lock.json` file
     - [x] in `.versionrc` has `monorepo-pkg-path` field as string list, will auto update `package.json` file
       in `monorepo-pkg-path` path (v1.5.+)
+- [x] in `.versionrc` has `branch-check` field as string list, will check current branch match patterns, default is `["main"]` (v1.14.+)
 
 ```json
 {
@@ -177,6 +179,8 @@ $ convention-change-log init --dry-init
 $ convention-change-log --dry-run
 # --skip-worktree-check will skip check worktree (v1.8.1+)
 $ convention-change-log --dry-run --skip-worktree-check
+# --skip-branch will skip branch check, branch-check config at .versionrc (v1.14+)
+$ convention-change-log --dry-run --skip-branch
 
 # flat -r to set custom release version
 $ convention-change-log -r 0.1.0 --dry-run

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -52,6 +52,8 @@ $ convention-change-log init --dry-init
 $ convention-change-log --dry-run
 # --skip-worktree-check 将跳过检查 worktree (v1.8.1+)
 $ convention-change-log --dry-run --skip-worktree-check
+# --skip-branch 将跳过分支检查，分支检查配置在 .versionrc (v1.14+)
+$ convention-change-log --dry-run --skip-branch
 
 # 设置 -r 自定义发布版本
 $ convention-change-log -r 0.1.0 --dry-run
@@ -110,6 +112,7 @@ Set-Alias -Name ccl -Value convention-change-log
 
 - 请先在远程仓库，设置好 `分支保护规则` 和 `tag 保护规则`，防止误提交，或者删除 tag
 - 生成 CHANGELOG.md 前，最好合并到 主分支, 上面的别名 `gcmpt` 就可以快速切到主分支，并同步到最新信息（包括 tag 同步）
+- 从 v1.14+ 开始，默认会检查当前分支是否匹配 `branch-check` 配置（默认 `["main"]`），如需在非主分支执行可使用 `--skip-branch` 跳过检查
 - 检查当前分支的状态是可以进行固定版本后
 - 执行 `ccl --dry-run` 或者 `ccl --dry-run -r 1.2.3` 指定目标版本，确认 预期生成的 change log 是否是正确的
     - 未设置生成发行版本，则开启自动生成版本规则

--- a/cmd/kit/command/branch_check.go
+++ b/cmd/kit/command/branch_check.go
@@ -39,9 +39,11 @@ func MatchBranchPatterns(branchName string, patterns []string) bool {
 // CheckBranchAtRoot opens the git repo at rootPath and checks if the current branch matches patterns.
 // Returns (branchName, matched, error).
 func CheckBranchAtRoot(rootPath string, patterns []string) (string, bool, error) {
+	patterns = ResolveBranchCheckPatterns(patterns)
+
 	repo, err := git.NewRepositoryRemoteByPath("origin", rootPath)
 	if err != nil {
-		return "", false, fmt.Errorf("load git repository for branch check error: %s", err)
+		return "", false, fmt.Errorf("load git repository for branch check: %w", err)
 	}
 	branchName, err := repo.HeadBranchName()
 	if err != nil {

--- a/cmd/kit/command/branch_check.go
+++ b/cmd/kit/command/branch_check.go
@@ -1,0 +1,51 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/bar-counter/slog"
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/sinlov-go/go-git-tools/git"
+)
+
+// DefaultBranchCheckPatterns returns the default branch check patterns.
+func DefaultBranchCheckPatterns() []string {
+	return []string{"main"}
+}
+
+// ResolveBranchCheckPatterns returns patterns if non-empty, otherwise returns default patterns.
+func ResolveBranchCheckPatterns(patterns []string) []string {
+	if len(patterns) == 0 {
+		return DefaultBranchCheckPatterns()
+	}
+	return patterns
+}
+
+// MatchBranchPatterns checks if branchName matches any of the patterns using doublestar glob matching.
+func MatchBranchPatterns(branchName string, patterns []string) bool {
+	for _, pattern := range patterns {
+		ok, err := doublestar.Match(pattern, branchName)
+		if err != nil {
+			slog.Warnf("branch check pattern %q error: %v", pattern, err)
+			continue
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckBranchAtRoot opens the git repo at rootPath and checks if the current branch matches patterns.
+// Returns (branchName, matched, error).
+func CheckBranchAtRoot(rootPath string, patterns []string) (string, bool, error) {
+	repo, err := git.NewRepositoryRemoteByPath("origin", rootPath)
+	if err != nil {
+		return "", false, fmt.Errorf("load git repository for branch check error: %s", err)
+	}
+	branchName, err := repo.HeadBranchName()
+	if err != nil {
+		return "", false, fmt.Errorf("get HEAD branch name error: %s", err)
+	}
+	return branchName, MatchBranchPatterns(branchName, patterns), nil
+}

--- a/cmd/kit/command/change_log_generator.go
+++ b/cmd/kit/command/change_log_generator.go
@@ -88,6 +88,7 @@ type GenerateConfig struct {
 	AutoPush bool
 
 	SkipWorktreeDirtyCheck bool
+	SkipBranchCheck        bool
 	IsOnlyChangeVersion    bool
 
 	AppendMonoRepoPath []string

--- a/cmd/kit/command/flag.go
+++ b/cmd/kit/command/flag.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/convention-change/convention-change-log/cmd/kit/constant"
 	"github.com/convention-change/convention-change-log/convention"
 	"github.com/urfave/cli/v2"
-	"strings"
 )
 
 // MainFlag
@@ -18,8 +19,11 @@ func MainFlag() []cli.Flag {
 		//	Value: "",
 		//},
 		&cli.StringFlag{
-			Name:    "release-as",
-			Usage:   fmt.Sprintf("Specify the release type manually (like npm version <major|minor|patch>) if not setting will use semver by history, if first release will change to %s", convention.DefaultSemverVersion),
+			Name: "release-as",
+			Usage: fmt.Sprintf(
+				"Specify the release type manually (like npm version <major|minor|patch>) if not setting will use semver by history, if first release will change to %s",
+				convention.DefaultSemverVersion,
+			),
 			Aliases: []string{"r"},
 		},
 		&cli.StringFlag{
@@ -89,8 +93,11 @@ func GlobalFlag() []cli.Flag {
 			EnvVars: []string{constant.EnvKeyDryRunDisable},
 		},
 		&cli.StringFlag{
-			Name:    "git-info-scheme",
-			Usage:   fmt.Sprintf("git info scheme, only support: %s", strings.Join(gitInfoSchemeSupport, ", ")),
+			Name: "git-info-scheme",
+			Usage: fmt.Sprintf(
+				"git info scheme, only support: %s",
+				strings.Join(gitInfoSchemeSupport, ", "),
+			),
 			Value:   "https",
 			EnvVars: []string{constant.EnvKeyGitInfoScheme},
 		},
@@ -98,6 +105,11 @@ func GlobalFlag() []cli.Flag {
 			Name:    "skip-worktree-check",
 			Usage:   "skip git worktree dirty check",
 			EnvVars: []string{constant.EnvKeySkipWorktreeCheck},
+		},
+		&cli.BoolFlag{
+			Name:    "skip-branch",
+			Usage:   "skip git branch check (v1.14.+)",
+			EnvVars: []string{constant.EnvKeySkipBranchCheck},
 		},
 	}
 }

--- a/cmd/kit/command/global.go
+++ b/cmd/kit/command/global.go
@@ -3,6 +3,10 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/bar-counter/slog"
 	"github.com/convention-change/convention-change-log/cmd/kit/command/exit_cli"
 	"github.com/convention-change/convention-change-log/cmd/kit/constant"
@@ -12,9 +16,6 @@ import (
 	"github.com/sinlov-go/go-common-lib/pkg/string_tools"
 	"github.com/sinlov-go/go-git-tools/git_info"
 	"github.com/urfave/cli/v2"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type GlobalConfig struct {
@@ -41,9 +42,7 @@ type (
 	}
 )
 
-var (
-	cmdGlobalEntry *GlobalCommand
-)
+var cmdGlobalEntry *GlobalCommand
 
 // CmdGlobalEntry
 //
@@ -56,7 +55,6 @@ func CmdGlobalEntry() *GlobalCommand {
 //
 //	do global command exec
 func (c *GlobalCommand) globalExec() error {
-
 	slog.Debug("-> start GlobalAction")
 
 	if c.GenerateConfig.AutoPush {
@@ -66,7 +64,10 @@ func (c *GlobalCommand) globalExec() error {
 
 	_, err := git_info.IsPathGitManagementRoot(c.GitRootPath)
 	if err != nil {
-		return exit_cli.Format("cli run path not git repository root, please check path at: %s", c.GitRootPath)
+		return exit_cli.Format(
+			"cli run path not git repository root, please check path at: %s",
+			c.GitRootPath,
+		)
 	}
 
 	clGenerator := NewChangeLogGenerator(c.GitRootPath)
@@ -80,6 +81,27 @@ func (c *GlobalCommand) globalExec() error {
 	if errCheckRepository != nil {
 		slog.Error("check repository err: %v", errCheckRepository)
 		return errCheckRepository
+	}
+
+	// branch check
+	if !c.GenerateConfig.SkipBranchCheck {
+		patterns := ResolveBranchCheckPatterns(c.ChangeLogSpec.BranchCheck)
+		headBranch := clGenerator.GetHeadBranchName()
+		if !MatchBranchPatterns(headBranch, patterns) {
+			if c.DryRun {
+				slog.Warnf(
+					"current branch %q does not match branch-check patterns %v, this may not be the intended release branch",
+					headBranch,
+					patterns,
+				)
+			} else {
+				return exit_cli.Format(
+					"current branch %q does not match branch-check patterns %v, please switch to a matching branch or use --skip-branch",
+					headBranch,
+					patterns,
+				)
+			}
+		}
 	}
 
 	if !c.GenerateConfig.SkipWorktreeDirtyCheck {
@@ -192,7 +214,10 @@ func withGlobalFlag(c *cli.Context, cliVersion, cliName string) (*GlobalCommand,
 	gitInfoScheme := c.String("git-info-scheme")
 
 	if !string_tools.StringInArr(gitInfoScheme, gitInfoSchemeSupport) {
-		return nil, exit_cli.Format("--git-info-scheme only support %s", strings.Join(gitInfoSchemeSupport, ", "))
+		return nil, exit_cli.Format(
+			"--git-info-scheme only support %s",
+			strings.Join(gitInfoSchemeSupport, ", "),
+		)
 	}
 
 	generateConfig := GenerateConfig{
@@ -210,6 +235,7 @@ func withGlobalFlag(c *cli.Context, cliVersion, cliName string) (*GlobalCommand,
 		AutoPush: isAutoPush,
 
 		SkipWorktreeDirtyCheck: c.Bool("skip-worktree-check"),
+		SkipBranchCheck:        c.Bool("skip-branch"),
 
 		IsOnlyChangeVersion: c.Bool("change-version"),
 
@@ -277,7 +303,11 @@ func GlobalAction(c *cli.Context) error {
 
 	isVerbose := c.Bool("verbose")
 	if isVerbose {
-		slog.Infof("-> start run command: %s, version %s", cmdGlobalEntry.Name, cmdGlobalEntry.Version)
+		slog.Infof(
+			"-> start run command: %s, version %s",
+			cmdGlobalEntry.Name,
+			cmdGlobalEntry.Version,
+		)
 	}
 
 	err := cmdGlobalEntry.globalExec()
@@ -295,7 +325,11 @@ func GlobalAction(c *cli.Context) error {
 func GlobalAfterAction(c *cli.Context) error {
 	isVerbose := c.Bool("verbose")
 	if isVerbose {
-		slog.Infof("-> finish run command: %s, version %s", cmdGlobalEntry.Name, cmdGlobalEntry.Version)
+		slog.Infof(
+			"-> finish run command: %s, version %s",
+			cmdGlobalEntry.Name,
+			cmdGlobalEntry.Version,
+		)
 	}
 	return nil
 }

--- a/cmd/kit/command/global.go
+++ b/cmd/kit/command/global.go
@@ -84,12 +84,13 @@ func (c *GlobalCommand) globalExec() error {
 	}
 
 	// branch check
+	branchCheckWarning := ""
 	if !c.GenerateConfig.SkipBranchCheck {
 		patterns := ResolveBranchCheckPatterns(c.ChangeLogSpec.BranchCheck)
 		headBranch := clGenerator.GetHeadBranchName()
 		if !MatchBranchPatterns(headBranch, patterns) {
 			if c.DryRun {
-				slog.Warnf(
+				branchCheckWarning = fmt.Sprintf(
 					"current branch %q does not match branch-check patterns %v, this may not be the intended release branch",
 					headBranch,
 					patterns,
@@ -140,6 +141,9 @@ func (c *GlobalCommand) globalExec() error {
 
 		if c.DryRun {
 			clGenerator.DryRunChangeVersion()
+			if branchCheckWarning != "" {
+				slog.Warnf("%s", branchCheckWarning)
+			}
 			return nil
 		}
 
@@ -159,6 +163,9 @@ func (c *GlobalCommand) globalExec() error {
 		clGenerator.DryRun()
 		if c.GenerateConfig.SkipWorktreeDirtyCheck {
 			slog.Warnf("skip worktree dirty check, this will let new tag not you want!")
+		}
+		if branchCheckWarning != "" {
+			slog.Warnf("%s", branchCheckWarning)
 		}
 		return nil
 	}

--- a/cmd/kit/command/subcommand_init/subCmdInit.go
+++ b/cmd/kit/command/subcommand_init/subCmdInit.go
@@ -1,6 +1,7 @@
 package subcommand_init
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -39,6 +40,7 @@ type InitCommand struct {
 func (n *InitCommand) Exec() error {
 	slog.Debugf("-> Exec subCommand [ %s ]", commandName)
 
+	var branchCheckWarning string
 	// branch check
 	if !n.SkipBranchCheck {
 		branchName, matched, err := command.CheckBranchAtRoot(n.GitRootPath, n.BranchCheckPatterns)
@@ -46,7 +48,7 @@ func (n *InitCommand) Exec() error {
 			slog.Warnf("branch check error: %v", err)
 		} else if !matched {
 			if n.DryRun {
-				slog.Warnf(
+				branchCheckWarning = fmt.Sprintf(
 					"current branch %q does not match branch-check patterns %v, this may not be the intended branch",
 					branchName,
 					n.BranchCheckPatterns,
@@ -60,6 +62,12 @@ func (n *InitCommand) Exec() error {
 			}
 		}
 	}
+
+	defer func() {
+		if branchCheckWarning != "" {
+			slog.Warnf("%s", branchCheckWarning)
+		}
+	}()
 
 	if filepath_plus.PathExistsFast(n.TargetFile) {
 		color.Yellowf("init versionrc file is exists, file: %s\n", n.TargetFile)

--- a/cmd/kit/command/subcommand_init/subCmdInit.go
+++ b/cmd/kit/command/subcommand_init/subCmdInit.go
@@ -1,16 +1,16 @@
 package subcommand_init
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/bar-counter/slog"
 	convention_change_log "github.com/convention-change/convention-change-log"
 	"github.com/convention-change/convention-change-log/cmd/kit/command"
 	"github.com/convention-change/convention-change-log/cmd/kit/command/exit_cli"
 	"github.com/convention-change/convention-change-log/cmd/kit/constant"
 	"github.com/convention-change/convention-change-log/convention"
 	"github.com/convention-change/convention-change-log/internal/tools"
-	"os"
-	"path/filepath"
-
-	"github.com/bar-counter/slog"
 	"github.com/convention-change/convention-change-log/internal/urfave_cli"
 	"github.com/gookit/color"
 	"github.com/sinlov-go/go-common-lib/pkg/filepath_plus"
@@ -29,10 +29,37 @@ type InitCommand struct {
 
 	TargetFile string
 	MoreConfig bool
+
+	SkipBranchCheck     bool
+	DryRun              bool
+	BranchCheckPatterns []string
+	GitRootPath         string
 }
 
 func (n *InitCommand) Exec() error {
 	slog.Debugf("-> Exec subCommand [ %s ]", commandName)
+
+	// branch check
+	if !n.SkipBranchCheck {
+		branchName, matched, err := command.CheckBranchAtRoot(n.GitRootPath, n.BranchCheckPatterns)
+		if err != nil {
+			slog.Warnf("branch check error: %v", err)
+		} else if !matched {
+			if n.DryRun {
+				slog.Warnf(
+					"current branch %q does not match branch-check patterns %v, this may not be the intended branch",
+					branchName,
+					n.BranchCheckPatterns,
+				)
+			} else {
+				return exit_cli.Format(
+					"current branch %q does not match branch-check patterns %v, please switch to a matching branch or use --skip-branch",
+					branchName,
+					n.BranchCheckPatterns,
+				)
+			}
+		}
+	}
 
 	if filepath_plus.PathExistsFast(n.TargetFile) {
 		color.Yellowf("init versionrc file is exists, file: %s\n", n.TargetFile)
@@ -48,7 +75,12 @@ func (n *InitCommand) Exec() error {
 			return nil
 		}
 
-		err := filepath_plus.WriteFileByByte(n.TargetFile, []byte(convention_change_log.ResVersionRcBeautyJson), os.FileMode(0o666), false)
+		err := filepath_plus.WriteFileByByte(
+			n.TargetFile,
+			[]byte(convention_change_log.ResVersionRcBeautyJson),
+			os.FileMode(0o666),
+			false,
+		)
 		if err != nil {
 			slog.Error("init .versionrc file err: %v", err)
 			return exit_cli.Err(err)
@@ -100,12 +132,18 @@ func withEntry(c *cli.Context) (*InitCommand, error) {
 	targetFile := filepath.Join(globalEntry.GitRootPath, constant.VersionRcFileName)
 
 	return &InitCommand{
-		isDebug: globalEntry.Verbose,
-
+		isDebug:   globalEntry.Verbose,
 		isDruInit: c.Bool("dry-init"),
 
 		TargetFile: targetFile,
 		MoreConfig: c.Bool("more"),
+
+		SkipBranchCheck: globalEntry.GenerateConfig.SkipBranchCheck,
+		DryRun:          globalEntry.DryRun,
+		BranchCheckPatterns: command.ResolveBranchCheckPatterns(
+			globalEntry.ChangeLogSpec.BranchCheck,
+		),
+		GitRootPath: globalEntry.GitRootPath,
 	}, nil
 }
 

--- a/cmd/kit/command/subcommand_init/subCmdInit.go
+++ b/cmd/kit/command/subcommand_init/subCmdInit.go
@@ -46,7 +46,7 @@ func (n *InitCommand) Exec() error {
 		branchName, matched, err := command.CheckBranchAtRoot(n.GitRootPath, n.BranchCheckPatterns)
 		if err != nil {
 			slog.Warnf("branch check error: %v", err)
-		} else if !matched {
+		} else if !matched && !filepath_plus.PathExistsFast(n.TargetFile) {
 			if n.DryRun {
 				branchCheckWarning = fmt.Sprintf(
 					"current branch %q does not match branch-check patterns %v, this may not be the intended branch",

--- a/cmd/kit/constant/env.go
+++ b/cmd/kit/constant/env.go
@@ -12,6 +12,8 @@ const (
 
 	EnvKeySkipWorktreeCheck = "CLI_SKIP_WORKTREE_CHECK"
 
+	EnvKeySkipBranchCheck = "CLI_SKIP_BRANCH_CHECK"
+
 	// EnvKeyCliTimeoutSecond
 	//	Provides the timeout second flag
 	EnvKeyCliTimeoutSecond = "CLI_CONFIG_TIMEOUT_SECOND"

--- a/convention/changeLogSpec.go
+++ b/convention/changeLogSpec.go
@@ -3,6 +3,7 @@ package convention
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/sinlov-go/go-common-lib/pkg/filepath_plus"
 )
 
@@ -20,7 +21,6 @@ const (
 // struct
 // scheme See: https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/schema.json
 type ConventionalChangeLogSpec struct {
-
 	// Types
 	//
 	Types []Types `json:"types,omitempty"`
@@ -78,11 +78,14 @@ type ConventionalChangeLogSpec struct {
 	// MonoRepoPkgPathList
 	// monorepo package path list
 	MonoRepoPkgPathList []string `json:"monorepo-pkg-path,omitempty"`
+
+	// BranchCheck
+	//	branch name patterns to check when running commands, uses doublestar glob matching
+	// default is ["main"]
+	BranchCheck []string `json:"branch-check,omitempty"`
 }
 
-var (
-	defaultConventionalChangeLogSpec *ConventionalChangeLogSpec
-)
+var defaultConventionalChangeLogSpec *ConventionalChangeLogSpec
 
 // SimplifyConventionalChangeLogSpec
 // return simplify ConventionalChangeLogSpec
@@ -156,6 +159,7 @@ func DefaultConventionalChangeLogSpec() ConventionalChangeLogSpec {
 	defaultConventionalChangeLogSpec.IssueUrlFormat = DefaultIssueUrlFormat
 	defaultConventionalChangeLogSpec.UserUrlFormat = DefaultUserUrlFormat
 	defaultConventionalChangeLogSpec.ReleaseCommitMessageFormat = DefaultReleaseCommitMessageFormat
+	defaultConventionalChangeLogSpec.BranchCheck = []string{"main"}
 
 	return *defaultConventionalChangeLogSpec
 }
@@ -238,6 +242,10 @@ func LoadConventionalChangeLogSpecByData(logSpec []byte) (*ConventionalChangeLog
 		spec.ReleaseCommitMessageFormat = DefaultReleaseCommitMessageFormat
 	}
 
+	if len(spec.BranchCheck) == 0 {
+		spec.BranchCheck = []string{"main"}
+	}
+
 	return &spec, nil
 }
 
@@ -251,11 +259,17 @@ func LoadConventionalChangeLogSpecByPath(specFilePath string) (*ConventionalChan
 	if filepath_plus.PathExistsFast(specFilePath) {
 		specByte, errReadSpec := filepath_plus.ReadFileAsByte(specFilePath)
 		if errReadSpec != nil {
-			return nil, fmt.Errorf("load ConventionalChangeLogSpec by path error: %s", errReadSpec.Error())
+			return nil, fmt.Errorf(
+				"load ConventionalChangeLogSpec by path error: %s",
+				errReadSpec.Error(),
+			)
 		}
 		spec, errReadSpec := LoadConventionalChangeLogSpecByData(specByte)
 		if errReadSpec != nil {
-			return nil, fmt.Errorf("load ConventionalChangeLogSpec by path error: %s", errReadSpec.Error())
+			return nil, fmt.Errorf(
+				"load ConventionalChangeLogSpec by path error: %s",
+				errReadSpec.Error(),
+			)
 		}
 		changeLogSpec = spec
 	} else {

--- a/convention/testdata/TestLoadConventionalChangeLogSpecByData/cover_git_info_scheme.golden
+++ b/convention/testdata/TestLoadConventionalChangeLogSpecByData/cover_git_info_scheme.golden
@@ -24,5 +24,8 @@
   "issueUrlFormat": "{{scheme}}://{{host}}/{{owner}}/{{repository}}/issues/{{id}}",
   "userUrlFormat": "{{scheme}://{{host}}/{{user}}",
   "releaseCommitMessageFormat": "chore(release): {{currentTag}}",
-  "cover-git-info-scheme": "http"
+  "cover-git-info-scheme": "http",
+  "branch-check": [
+    "main"
+  ]
 }

--- a/convention/testdata/TestLoadConventionalChangeLogSpecByData/cover_http_host.golden
+++ b/convention/testdata/TestLoadConventionalChangeLogSpecByData/cover_http_host.golden
@@ -24,5 +24,8 @@
   "issueUrlFormat": "{{scheme}}://{{host}}/{{owner}}/{{repository}}/issues/{{id}}",
   "userUrlFormat": "{{scheme}://{{host}}/{{user}}",
   "releaseCommitMessageFormat": "chore(release): {{currentTag}}",
-  "cover-http-host": "github.com:443"
+  "cover-http-host": "github.com:443",
+  "branch-check": [
+    "main"
+  ]
 }

--- a/convention/testdata/TestLoadConventionalChangeLogSpecByData/full.golden
+++ b/convention/testdata/TestLoadConventionalChangeLogSpecByData/full.golden
@@ -77,5 +77,8 @@
   "compareUrlFormat": "{{scheme}}://{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}",
   "issueUrlFormat": "{{scheme}}://{{host}}/{{owner}}/{{repository}}/issues/{{id}}",
   "userUrlFormat": "{{scheme}://{{host}}/{{user}}",
-  "releaseCommitMessageFormat": "chore(release): {{currentTag}}"
+  "releaseCommitMessageFormat": "chore(release): {{currentTag}}",
+  "branch-check": [
+    "main"
+  ]
 }

--- a/convention/testdata/TestLoadConventionalChangeLogSpecByData/monorepo_pkg_path.golden
+++ b/convention/testdata/TestLoadConventionalChangeLogSpecByData/monorepo_pkg_path.golden
@@ -27,5 +27,8 @@
   "monorepo-pkg-path": [
     "foo",
     "bar"
+  ],
+  "branch-check": [
+    "main"
   ]
 }

--- a/convention/testdata/TestLoadConventionalChangeLogSpecByData/sample.golden
+++ b/convention/testdata/TestLoadConventionalChangeLogSpecByData/sample.golden
@@ -23,5 +23,8 @@
   "compareUrlFormat": "{{scheme}}://{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}",
   "issueUrlFormat": "{{scheme}}://{{host}}/{{owner}}/{{repository}}/issues/{{id}}",
   "userUrlFormat": "{{scheme}://{{host}}/{{user}}",
-  "releaseCommitMessageFormat": "chore(release): {{currentTag}}"
+  "releaseCommitMessageFormat": "chore(release): {{currentTag}}",
+  "branch-check": [
+    "main"
+  ]
 }

--- a/doc/feature/99-feat-check-workspace-brach-is-default-branch.md
+++ b/doc/feature/99-feat-check-workspace-brach-is-default-branch.md
@@ -1,0 +1,71 @@
+# Feature: Check workspace branch is default branch
+
+> Since v1.14.0
+
+## Overview
+
+This feature checks whether the current git workspace branch matches the expected default branch before running changelog generation or initialization. This prevents accidentally creating releases from feature branches.
+
+## Configuration
+
+### `.versionrc` key `branch-check`
+
+Add a `branch-check` key to your `.versionrc` file with an array of glob patterns:
+
+```json
+{
+  "branch-check": ["main"]
+}
+```
+
+- **Default**: `["main"]` if not set
+- **Matching**: Uses [doublestar v4](https://github.com/bmatcuk/doublestar) glob pattern matching
+- Supports patterns like `main`, `release-*`, `{main,master}`, etc.
+
+### Global flag `--skip-branch`
+
+Skip the branch check entirely:
+
+```bash
+$ convention-change-log --skip-branch --dry-run
+```
+
+Environment variable: `CLI_SKIP_BRANCH_CHECK=true`
+
+## Behavior
+
+| Mode | Branch matches | Branch does NOT match |
+|------|---------------|----------------------|
+| `--dry-run` (default) | Proceeds normally | Prints warning, continues |
+| `--dry-run-disable` | Proceeds normally | Exits with error |
+| `--skip-branch` | Skips check | Skips check |
+
+## Affected commands
+
+- Main generate command (default action)
+- `init` subcommand
+
+## Examples
+
+### Custom branch patterns
+
+```json
+{
+  "branch-check": ["main", "release-*"]
+}
+```
+
+### Skip branch check
+
+```bash
+$ convention-change-log --skip-branch
+$ convention-change-log init --skip-branch
+```
+
+### Dry-run shows warning on wrong branch
+
+```bash
+$ git checkout feature/some-work
+$ convention-change-log --dry-run
+# WARNING: current branch "feature/some-work" does not match branch-check patterns [main], this may not be the intended release branch
+```

--- a/doc/feature/99-feat-check-workspace-brach-is-default-branch.md
+++ b/doc/feature/99-feat-check-workspace-brach-is-default-branch.md
@@ -20,7 +20,7 @@ Add a `branch-check` key to your `.versionrc` file with an array of glob pattern
 
 - **Default**: `["main"]` if not set
 - **Matching**: Uses [doublestar v4](https://github.com/bmatcuk/doublestar) glob pattern matching
-- Supports patterns like `main`, `release-*`, `{main,master}`, etc.
+- Supports patterns like `main`, `master`, `release-*`, `feature/**`, etc.
 
 ### Global flag `--skip-branch`
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/bar-counter/slog v1.4.1
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/elliotchance/orderedmap/v2 v2.7.0
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/gookit/color v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/aymerick/raymond v2.0.2+incompatible h1:VEp3GpgdAnv9B2GFyTvqgcKvY+mfK
 github.com/aymerick/raymond v2.0.2+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/bar-counter/slog v1.4.1 h1:NcRyW3ycaLpA5pmOU0bicK8osJJ8JTea8z91vRsUbgc=
 github.com/bar-counter/slog v1.4.1/go.mod h1:5yt5EPCZhprrW7qkxWneNzcho+26NMfeZXECmPtq8wY=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/chainguard-dev/git-urls v1.0.2 h1:pSpT7ifrpc5X55n4aTTm7FFUE+ZQHKiqpiwNkJrVcKQ=
 github.com/chainguard-dev/git-urls v1.0.2/go.mod h1:rbGgj10OS7UgZlbzdUQIQpT0k/D4+An04HJY7Ol+Y/o=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=

--- a/resource/versionrc-beauty.json
+++ b/resource/versionrc-beauty.json
@@ -13,5 +13,6 @@
     {"type": "revert", "section":"⏪ Reverts", "hidden": false}
   ],
   "tag-prefix": "v",
-  "monorepo-pkg-path": []
+  "monorepo-pkg-path": [],
+  "branch-check": ["main"]
 }


### PR DESCRIPTION
### Description of Changes

- Add global --skip-branch flag (env CLI_SKIP_BRANCH_CHECK) to skip git branch verification before changelog generation and init
- Add branch-check config key in .versionrc as a glob pattern list (default ["main"]), matched with github.com/bmatcuk/doublestar/v4
- Wire branch check into the main generate command and the init subcommand; dry-run warns on mismatch, normal mode exits with error
- Add branch-check to resource/versionrc-beauty.json template and this repo's .versionrc
- Update README.md and README.zh-Hans.md with flag usage and config docs
- Regenerate 5 golden files under convention/testdata to include the new branch-check default field

### Related Issues

List related issues here

- #99